### PR TITLE
Fixes 'could not find coffee-script-source-1.1.3' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Ruby on Rails
 
     $ cd rails_app
-    $ bundle
+    $ bundle update --source coffee-script-source
     $ rake db:setup
     $ rails s
 


### PR DESCRIPTION
Uses strategy proposed in this SO post to resolve the following error 'Could not find coffee-script-source-1.1.3 in any of the sources' 

http://stackoverflow.com/questions/22063061/could-not-find-coffee-script-source-1-1-3-in-any-of-the-sources
